### PR TITLE
Fix unused Azure monitor import

### DIFF
--- a/src/backend/app_kernel.py
+++ b/src/backend/app_kernel.py
@@ -10,7 +10,6 @@ from app_config import config
 from auth.auth_utils import get_authenticated_user_details
 
 # Azure monitoring
-from azure.monitor.opentelemetry import configure_azure_monitor
 from config_kernel import Config
 from event_utils import track_event_if_configured
 
@@ -38,7 +37,7 @@ from utils_kernel import initialize_runtime_and_context, rai_success
 connection_string = os.getenv("APPLICATIONINSIGHTS_CONNECTION_STRING")
 if connection_string:
     # Configure Application Insights if the Instrumentation Key is found
-    #configure_azure_monitor(connection_string=connection_string)
+    # configure_azure_monitor(connection_string=connection_string)
     logging.info(
         "Application Insights configured with the provided Instrumentation Key"
     )


### PR DESCRIPTION
## Summary
- drop unused `configure_azure_monitor` import
- tidy comment to pass flake8

## Testing
- `flake8`


------
https://chatgpt.com/codex/tasks/task_e_685357e46d6c8331be6e18600a8f567c