### PR TITLE
Add requests dependency

### DIFF
--- a/src/backend/pyproject.toml
+++ b/src/backend/pyproject.toml
@@ -28,4 +28,5 @@ dependencies = [
     "python-multipart>=0.0.20",
     "semantic-kernel>=1.28.1",
     "uvicorn>=0.34.2",
+    "requests>=2.32.3",
 ]

--- a/src/backend/requirements.txt
+++ b/src/backend/requirements.txt
@@ -28,3 +28,4 @@ pytest>=8.2,<9  # Compatible version for pytest-asyncio
 pytest-asyncio==0.24.0
 pytest-cov==5.0.0
 
+requests>=2.32.3


### PR DESCRIPTION
## Summary
- add `requests` as a dependency for backend

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'azure')*

------
https://chatgpt.com/codex/tasks/task_e_685357dbc8c883319c33c6660387d944